### PR TITLE
Make cyclical dependency explicit for amd-ification

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,4 @@
+{
+  "presets": ["stage-0", "es2015", "react"],
+  "plugins": ["transform-decorators-legacy"]
+}

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Once the lazy loaded component is loaded, do not detect scroll/resize event anym
 
 Type: Number/Array(Number) Default: 0
 
-Say if you want to preload a module even if it's 100px below the viewport (user have to scroll 100px more to see this module), you can set `offset` props to `100`. On the other hand, if you want to delay loading a module even if it's top edge has already appeared at viewport, set `offset` props to negative number will make it delay loading.
+Say if you want to preload a component even if it's 100px below the viewport (user have to scroll 100px more to see this component), you can set `offset` props to `100`. On the other hand, if you want to delay loading a component even if it's top edge has already appeared at viewport, set `offset` to negative number.
 
 If you provide this props with array like `[200, 200]`, it will set top edge offset and bottom edge offset respectively.
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ const App = React.createClass({
                                    if you're concerned about improving performance */
           <MyComponent />
         </LazyLoad>
-        <LazyLoad height={200} offset={100}> 
+        <LazyLoad height={200} offset={100}>
                                 /* This component will be loaded when it's top
                                    edge is 100px from viewport. It's useful to
                                    make user ignorant about lazy load effect. */
@@ -170,6 +170,7 @@ Using `LazyLoad` component will help ease this situation by only update componen
 ## Contributors
 
 1. [lancehub](https://github.com/lancehub)
+2. [doug-wade](https://github.com/doug-wade)
 
 
 ## License

--- a/examples/pages/decorator.js
+++ b/examples/pages/decorator.js
@@ -53,4 +53,3 @@ export default class Decorator extends Component {
     );
   }
 }
-

--- a/lib/decorator.js
+++ b/lib/decorator.js
@@ -6,9 +6,9 @@ Object.defineProperty(exports, "__esModule", {
 
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
-var _ = require('.');
+var _index = require('./index');
 
-var _2 = _interopRequireDefault(_);
+var _index2 = _interopRequireDefault(_index);
 
 var _react = require('react');
 
@@ -45,7 +45,7 @@ exports.default = function () {
         key: 'render',
         value: function render() {
           return _react2.default.createElement(
-            _2.default,
+            _index2.default,
             options,
             _react2.default.createElement(WrappedComponent, this.props)
           );

--- a/lib/decorator.js
+++ b/lib/decorator.js
@@ -1,57 +1,58 @@
 'use strict';
 
-exports.__esModule = true;
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
 
-var _createClass = (function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ('value' in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; })();
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
+var _ = require('.');
 
-function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function'); } }
-
-function _inherits(subClass, superClass) { if (typeof superClass !== 'function' && superClass !== null) { throw new TypeError('Super expression must either be null or a function, not ' + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
-
-var _index = require('./index');
-
-var _index2 = _interopRequireDefault(_index);
+var _2 = _interopRequireDefault(_);
 
 var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
 
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
 var getDisplayName = function getDisplayName(WrappedComponent) {
   return WrappedComponent.displayName || WrappedComponent.name || 'Component';
 };
 
-exports['default'] = function () {
+exports.default = function () {
   var options = arguments.length <= 0 || arguments[0] === undefined ? {} : arguments[0];
-
   return function lazyload(WrappedComponent) {
-    return (function (_Component) {
+    return function (_Component) {
       _inherits(LazyLoadDecorated, _Component);
 
       function LazyLoadDecorated() {
         _classCallCheck(this, LazyLoadDecorated);
 
-        _Component.apply(this, arguments);
+        var _this = _possibleConstructorReturn(this, Object.getPrototypeOf(LazyLoadDecorated).call(this));
+
+        _this.displayName = 'LazyLoad' + getDisplayName(WrappedComponent);
+        return _this;
       }
 
-      LazyLoadDecorated.prototype.render = function render() {
-        return _react2['default'].createElement(
-          _index2['default'],
-          options,
-          _react2['default'].createElement(WrappedComponent, this.props)
-        );
-      };
-
-      _createClass(LazyLoadDecorated, null, [{
-        key: 'displayName',
-        value: 'LazyLoad' + getDisplayName(WrappedComponent),
-        enumerable: true
+      _createClass(LazyLoadDecorated, [{
+        key: 'render',
+        value: function render() {
+          return _react2.default.createElement(
+            _2.default,
+            options,
+            _react2.default.createElement(WrappedComponent, this.props)
+          );
+        }
       }]);
 
       return LazyLoadDecorated;
-    })(_react.Component);
+    }(_react.Component);
   };
 };
-
-module.exports = exports['default'];

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,15 +1,11 @@
-/**
- * react-lazyload
- */
 'use strict';
 
-exports.__esModule = true;
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.lazyload = undefined;
 
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
-
-function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function'); } }
-
-function _inherits(subClass, superClass) { if (typeof superClass !== 'function' && superClass !== null) { throw new TypeError('Super expression must either be null or a function, not ' + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 var _react = require('react');
 
@@ -19,19 +15,34 @@ var _reactDom = require('react-dom');
 
 var _reactDom2 = _interopRequireDefault(_reactDom);
 
-var _utilsEvent = require('./utils/event');
+var _event = require('./utils/event');
 
-var _utilsScrollParent = require('./utils/scrollParent');
+var _scrollParent = require('./utils/scrollParent');
 
-var _utilsScrollParent2 = _interopRequireDefault(_utilsScrollParent);
+var _scrollParent2 = _interopRequireDefault(_scrollParent);
 
-var _utilsDebounce = require('./utils/debounce');
+var _debounce = require('./utils/debounce');
 
-var _utilsDebounce2 = _interopRequireDefault(_utilsDebounce);
+var _debounce2 = _interopRequireDefault(_debounce);
 
-var _utilsThrottle = require('./utils/throttle');
+var _throttle = require('./utils/throttle');
 
-var _utilsThrottle2 = _interopRequireDefault(_utilsThrottle);
+var _throttle2 = _interopRequireDefault(_throttle);
+
+var _decorator = require('./decorator');
+
+var _decorator2 = _interopRequireDefault(_decorator);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; } /**
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                * react-lazyload
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                */
+
 
 var LISTEN_FLAG = 'data-lazyload-listened';
 var listeners = [];
@@ -47,14 +58,15 @@ var heightDiffThreshold = 20;
  * @return {bool}
  */
 var checkOverflowVisible = function checkOverflowVisible(component, parent) {
-  var node = _reactDom2['default'].findDOMNode(component);
+  var node = _reactDom2.default.findDOMNode(component);
 
   var scrollTop = parent.scrollTop;
   var parentBottom = scrollTop + parent.offsetHeight;
 
-  var _node$getBoundingClientRect = node.getBoundingClientRect();
+  var _node$getBoundingClie = node.getBoundingClientRect();
 
-  var elementHeight = _node$getBoundingClientRect.height;
+  var elementHeight = _node$getBoundingClie.height;
+
 
   var offsets = Array.isArray(component.props.offset) ? component.props.offset : [component.props.offset, component.props.offset]; // Be compatible with previous API
 
@@ -70,16 +82,16 @@ var checkOverflowVisible = function checkOverflowVisible(component, parent) {
  * @return {bool}
  */
 var checkNormalVisible = function checkNormalVisible(component) {
-  var node = _reactDom2['default'].findDOMNode(component);
+  var node = _reactDom2.default.findDOMNode(component);
 
   var supportPageOffset = window.pageXOffset !== undefined;
   var isCSS1Compat = (document.compatMode || '') === 'CSS1Compat';
   var scrollTop = supportPageOffset ? window.pageYOffset : isCSS1Compat ? document.documentElement.scrollTop : document.body.scrollTop;
 
-  var _node$getBoundingClientRect2 = node.getBoundingClientRect();
+  var _node$getBoundingClie2 = node.getBoundingClientRect();
 
-  var top = _node$getBoundingClientRect2.top;
-  var elementHeight = _node$getBoundingClientRect2.height;
+  var top = _node$getBoundingClie2.top;
+  var elementHeight = _node$getBoundingClie2.height;
 
   var elementTop = top + scrollTop; // element top relative to document
   var elementBottom = elementTop + elementHeight;
@@ -99,12 +111,12 @@ var checkNormalVisible = function checkNormalVisible(component) {
  * @param  {React} component   React component that respond to scroll and resize
  */
 var checkVisible = function checkVisible(component) {
-  var node = _reactDom2['default'].findDOMNode(component);
+  var node = _reactDom2.default.findDOMNode(component);
   if (!node) {
     return;
   }
 
-  var parent = _utilsScrollParent2['default'](node);
+  var parent = (0, _scrollParent2.default)(node);
   var isOverflow = parent !== (node.ownerDocument || document);
 
   var visible = isOverflow ? checkOverflowVisible(component, parent) : checkNormalVisible(component);
@@ -147,125 +159,133 @@ var lazyLoadHandler = function lazyLoadHandler() {
 };
 
 // Depending on component's props
-var delayType = undefined;
+var delayType = void 0;
 var finalLazyLoadHandler = null;
 
-var LazyLoad = (function (_Component) {
+var LazyLoad = function (_Component) {
   _inherits(LazyLoad, _Component);
 
   function LazyLoad(props) {
     _classCallCheck(this, LazyLoad);
 
-    _Component.call(this, props);
+    var _this = _possibleConstructorReturn(this, Object.getPrototypeOf(LazyLoad).call(this, props));
 
-    this.visible = false;
+    _this.visible = false;
 
-    if (_react2['default'].Children.count(this.props.children) > 1) {
+    if (_react2.default.Children.count(_this.props.children) > 1) {
       console.warn('[react-lazyload] Only one child is allowed to be passed to `LazyLoad`.');
     }
 
-    if (typeof this.props.height !== 'number') {
+    if (typeof _this.props.height !== 'number') {
       console.warn('[react-lazyload] Please add `height` props to <LazyLoad> for better performance.');
     }
 
-    if (this.props.wheel) {
+    if (_this.props.wheel) {
       // eslint-disable-line
       console.warn('[react-lazyload] Props `wheel` is not supported anymore, try set `overflow` for lazy loading in overflow containers.');
     }
+    return _this;
   }
 
-  LazyLoad.prototype.componentDidMount = function componentDidMount() {
-    // It's unlikely to change delay type for an application, this is mainly
-    // designed for tests
-    var needResetFinalLazyLoadHandler = false;
-    if (this.props.debounce !== undefined && delayType === 'throttle') {
-      console.warn('[react-lazyload] Previous delay function is `throttle`, now switching to `debounce`, try to set them unanimously');
-      needResetFinalLazyLoadHandler = true;
-    } else if (delayType === 'debounce' && this.props.debounce === undefined) {
-      console.warn('[react-lazyload] Previous delay function is `debounce`, now switching to `throttle`, try to set them unanimously');
-      needResetFinalLazyLoadHandler = true;
-    }
-
-    if (needResetFinalLazyLoadHandler) {
-      _utilsEvent.off(window, 'scroll', finalLazyLoadHandler);
-      _utilsEvent.off(window, 'resize', finalLazyLoadHandler);
-      finalLazyLoadHandler = null;
-    }
-
-    if (!finalLazyLoadHandler) {
-      if (this.props.debounce !== undefined) {
-        finalLazyLoadHandler = _utilsDebounce2['default'](lazyLoadHandler, typeof this.props.debounce === 'number' ? this.props.debounce : 300);
-        delayType = 'debounce';
-      } else {
-        finalLazyLoadHandler = _utilsThrottle2['default'](lazyLoadHandler, typeof this.props.throttle === 'number' ? this.props.throttle : 300);
-        delayType = 'throttle';
-      }
-    }
-
-    if (this.props.overflow) {
-      var _parent = _utilsScrollParent2['default'](_reactDom2['default'].findDOMNode(this));
-      if (_parent && _parent.getAttribute(LISTEN_FLAG) === null) {
-        _parent.addEventListener('scroll', finalLazyLoadHandler);
-        _parent.setAttribute(LISTEN_FLAG, 1);
-      }
-    } else if (listeners.length === 0 || needResetFinalLazyLoadHandler) {
-      var _props = this.props;
-      var _scroll = _props.scroll;
-      var resize = _props.resize;
-
-      if (_scroll) {
-        _utilsEvent.on(window, 'scroll', finalLazyLoadHandler);
+  _createClass(LazyLoad, [{
+    key: 'componentDidMount',
+    value: function componentDidMount() {
+      // It's unlikely to change delay type for an application, this is mainly
+      // designed for tests
+      var needResetFinalLazyLoadHandler = false;
+      if (this.props.debounce !== undefined && delayType === 'throttle') {
+        console.warn('[react-lazyload] Previous delay function is `throttle`, now switching to `debounce`, try to set them unanimously');
+        needResetFinalLazyLoadHandler = true;
+      } else if (delayType === 'debounce' && this.props.debounce === undefined) {
+        console.warn('[react-lazyload] Previous delay function is `debounce`, now switching to `throttle`, try to set them unanimously');
+        needResetFinalLazyLoadHandler = true;
       }
 
-      if (resize) {
-        _utilsEvent.on(window, 'resize', finalLazyLoadHandler);
+      if (needResetFinalLazyLoadHandler) {
+        (0, _event.off)(window, 'scroll', finalLazyLoadHandler);
+        (0, _event.off)(window, 'resize', finalLazyLoadHandler);
+        finalLazyLoadHandler = null;
       }
-    }
 
-    listeners.push(this);
-    checkVisible(this);
+      if (!finalLazyLoadHandler) {
+        if (this.props.debounce !== undefined) {
+          finalLazyLoadHandler = (0, _debounce2.default)(lazyLoadHandler, typeof this.props.debounce === 'number' ? this.props.debounce : 300);
+          delayType = 'debounce';
+        } else {
+          finalLazyLoadHandler = (0, _throttle2.default)(lazyLoadHandler, typeof this.props.throttle === 'number' ? this.props.throttle : 300);
+          delayType = 'throttle';
+        }
+      }
 
-    if (process.env.NODE_ENV !== 'production') {
-      if (this.props.placeholder) {
-        var node = _reactDom2['default'].findDOMNode(this);
-        if (!warnedAboutPlaceholderHeight && Math.abs(node.offsetHeight - this.props.height) > heightDiffThreshold) {
-          console.warn('[react-lazyload] A more specific `height` or `minHeight` for your own placeholder will result better lazyload performance.');
-          warnedAboutPlaceholderHeight = true;
+      if (this.props.overflow) {
+        var parent = (0, _scrollParent2.default)(_reactDom2.default.findDOMNode(this));
+        if (parent && parent.getAttribute(LISTEN_FLAG) === null) {
+          parent.addEventListener('scroll', finalLazyLoadHandler);
+          parent.setAttribute(LISTEN_FLAG, 1);
+        }
+      } else if (listeners.length === 0 || needResetFinalLazyLoadHandler) {
+        var _props = this.props;
+        var scroll = _props.scroll;
+        var resize = _props.resize;
+
+
+        if (scroll) {
+          (0, _event.on)(window, 'scroll', finalLazyLoadHandler);
+        }
+
+        if (resize) {
+          (0, _event.on)(window, 'resize', finalLazyLoadHandler);
+        }
+      }
+
+      listeners.push(this);
+      checkVisible(this);
+
+      if (process.env.NODE_ENV !== 'production') {
+        if (this.props.placeholder) {
+          var node = _reactDom2.default.findDOMNode(this);
+          if (!warnedAboutPlaceholderHeight && Math.abs(node.offsetHeight - this.props.height) > heightDiffThreshold) {
+            console.warn('[react-lazyload] A more specific `height` or `minHeight` for your own placeholder will result better lazyload performance.');
+            warnedAboutPlaceholderHeight = true;
+          }
         }
       }
     }
-  };
+  }, {
+    key: 'shouldComponentUpdate',
+    value: function shouldComponentUpdate() {
+      return this.visible;
+    }
+  }, {
+    key: 'componentWillUnmount',
+    value: function componentWillUnmount() {
+      if (this.props.overflow) {
+        var parent = (0, _scrollParent2.default)(_reactDom2.default.findDOMNode(this));
+        if (parent) {
+          parent.removeEventListener('scroll', finalLazyLoadHandler);
+          parent.removeAttribute(LISTEN_FLAG);
+        }
+      }
 
-  LazyLoad.prototype.shouldComponentUpdate = function shouldComponentUpdate() {
-    return this.visible;
-  };
+      var index = listeners.indexOf(this);
+      if (index !== -1) {
+        listeners.splice(index, 1);
+      }
 
-  LazyLoad.prototype.componentWillUnmount = function componentWillUnmount() {
-    if (this.props.overflow) {
-      var _parent2 = _utilsScrollParent2['default'](_reactDom2['default'].findDOMNode(this));
-      if (_parent2) {
-        _parent2.removeEventListener('scroll', finalLazyLoadHandler);
-        _parent2.removeAttribute(LISTEN_FLAG);
+      if (listeners.length === 0) {
+        (0, _event.off)(window, 'resize', finalLazyLoadHandler);
+        (0, _event.off)(window, 'scroll', finalLazyLoadHandler);
       }
     }
-
-    var index = listeners.indexOf(this);
-    if (index !== -1) {
-      listeners.splice(index, 1);
+  }, {
+    key: 'render',
+    value: function render() {
+      return this.visible ? this.props.children : this.props.placeholder ? this.props.placeholder : _react2.default.createElement('div', { style: { height: this.props.height }, className: 'lazyload-placeholder' });
     }
-
-    if (listeners.length === 0) {
-      _utilsEvent.off(window, 'resize', finalLazyLoadHandler);
-      _utilsEvent.off(window, 'scroll', finalLazyLoadHandler);
-    }
-  };
-
-  LazyLoad.prototype.render = function render() {
-    return this.visible ? this.props.children : this.props.placeholder ? this.props.placeholder : _react2['default'].createElement('div', { style: { height: this.props.height }, className: 'lazyload-placeholder' });
-  };
+  }]);
 
   return LazyLoad;
-})(_react.Component);
+}(_react.Component);
 
 LazyLoad.propTypes = {
   once: _react.PropTypes.bool,
@@ -289,10 +309,5 @@ LazyLoad.defaultProps = {
   scroll: true
 };
 
-exports['default'] = LazyLoad;
-
-var _decorator = require('./decorator');
-
-var _decorator2 = _interopRequireDefault(_decorator);
-
-exports.lazyload = _decorator2['default'];
+var lazyload = exports.lazyload = _decorator2.default;
+exports.default = LazyLoad;

--- a/lib/utils/debounce.js
+++ b/lib/utils/debounce.js
@@ -1,14 +1,15 @@
 "use strict";
 
-exports.__esModule = true;
-exports["default"] = debounce;
-
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.default = debounce;
 function debounce(func, wait, immediate) {
-  var timeout = undefined;
-  var args = undefined;
-  var context = undefined;
-  var timestamp = undefined;
-  var result = undefined;
+  var timeout = void 0;
+  var args = void 0;
+  var context = void 0;
+  var timestamp = void 0;
+  var result = void 0;
 
   var later = function later() {
     var last = +new Date() - timestamp;
@@ -44,5 +45,3 @@ function debounce(func, wait, immediate) {
     return result;
   };
 }
-
-module.exports = exports["default"];

--- a/lib/utils/event.js
+++ b/lib/utils/event.js
@@ -1,9 +1,10 @@
 "use strict";
 
-exports.__esModule = true;
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
 exports.on = on;
 exports.off = off;
-
 function on(el, eventName, callback) {
   if (el.addEventListener) {
     el.addEventListener(eventName, callback, false);

--- a/lib/utils/scrollParent.js
+++ b/lib/utils/scrollParent.js
@@ -1,12 +1,13 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
 /**
  * @fileOverview Find scroll parent
  */
 
-'use strict';
-
-exports.__esModule = true;
-
-exports['default'] = function (node) {
+exports.default = function (node) {
   if (!node) {
     return document;
   }
@@ -39,5 +40,3 @@ exports['default'] = function (node) {
 
   return node.ownerDocument || document;
 };
-
-module.exports = exports['default'];

--- a/lib/utils/throttle.js
+++ b/lib/utils/throttle.js
@@ -1,9 +1,10 @@
-/*eslint-disable */
 "use strict";
 
-exports.__esModule = true;
-exports["default"] = throttle;
-
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.default = throttle;
+/*eslint-disable */
 function throttle(fn, threshhold, scope) {
   threshhold || (threshhold = 250);
   var last, deferTimer;
@@ -25,5 +26,3 @@ function throttle(fn, threshhold, scope) {
     }
   };
 }
-
-module.exports = exports["default"];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-lazyload",
-  "version": "2.0.4",
+  "version": "2.1.0",
   "description": "Lazyload your Component, Image or anything matters the performance.",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -4,11 +4,11 @@
   "description": "Lazyload your Component, Image or anything matters the performance.",
   "main": "lib/index.js",
   "scripts": {
-    "test": "./node_modules/karma/bin/karma start test/karma.conf.js",
-    "demo:watch": "./node_modules/.bin/webpack-dev-server --inline --config webpack.config.js --content-base examples --port 8721",
-    "demo:build": "NODE_ENV=production ./node_modules/.bin/webpack",
-    "build": "./node_modules/.bin/babel src/ --out-dir lib/ --stage 0 --loose all",
-    "lint": "./node_modules/.bin/eslint -c .eslintrc src/"
+    "test": "karma start test/karma.conf.js",
+    "demo:watch": "webpack-dev-server --inline --config webpack.config.js --content-base examples --port 8721",
+    "demo:build": "NODE_ENV=production webpack",
+    "build": "babel src/ --out-dir lib/",
+    "lint": "eslint -c .eslintrc src/"
   },
   "repository": {
     "type": "git",
@@ -26,10 +26,15 @@
   },
   "homepage": "https://github.com/jasonslyvia/react-lazyload",
   "devDependencies": {
-    "babel": "~5.8.21",
-    "babel-core": "~5.8.21",
+    "babel": "~6.5.2",
+    "babel-cli": "^6.7.7",
+    "babel-core": "^6.8.0",
     "babel-eslint": "^6.0.2",
-    "babel-loader": "~5.3.2",
+    "babel-loader": "~6.2.4",
+    "babel-plugin-transform-decorators-legacy": "^1.3.4",
+    "babel-preset-es2015": "^6.6.0",
+    "babel-preset-stage-0": "^6.5.0",
+    "babel-preset-react": "^6.5.0",
     "chai": "^3.2.0",
     "chai-spies": "^0.7.1",
     "eslint": "^2.7.0",

--- a/src/decorator.js
+++ b/src/decorator.js
@@ -1,22 +1,21 @@
-import LazyLoad from './index';
+import LazyLoad from '.';
 import React, { Component } from 'react';
 
-const getDisplayName = (WrappedComponent) => {
-  return WrappedComponent.displayName || WrappedComponent.name || 'Component';
-};
+const getDisplayName = (WrappedComponent) => WrappedComponent.displayName || WrappedComponent.name || 'Component';
 
-export default (options = {}) => {
-  return function lazyload(WrappedComponent) {
-    return class LazyLoadDecorated extends Component {
-      static displayName = `LazyLoad${getDisplayName(WrappedComponent)}`;
+export default (options = {}) => function lazyload(WrappedComponent) {
+  return class LazyLoadDecorated extends Component {
+    constructor() {
+      super();
+      this.displayName = `LazyLoad${getDisplayName(WrappedComponent)}`;
+    }
 
-      render() {
-        return (
-          <LazyLoad {...options}>
-            <WrappedComponent {...this.props} />
-          </LazyLoad>
-        );
-      }
-    };
+    render() {
+      return (
+        <LazyLoad {...options}>
+          <WrappedComponent {...this.props} />
+        </LazyLoad>
+      );
+    }
   };
 };

--- a/src/decorator.js
+++ b/src/decorator.js
@@ -1,4 +1,4 @@
-import LazyLoad from '.';
+import LazyLoad from './index';
 import React, { Component } from 'react';
 
 const getDisplayName = (WrappedComponent) => WrappedComponent.displayName || WrappedComponent.name || 'Component';

--- a/src/index.js
+++ b/src/index.js
@@ -211,7 +211,7 @@ class LazyLoad extends Component {
         const node = ReactDom.findDOMNode(this);
         if (!warnedAboutPlaceholderHeight &&
             Math.abs(node.offsetHeight - this.props.height) > heightDiffThreshold) {
-          console.warn(`[react-lazyload] A more specific \`height\` or \`minHeight\` for your own placeholder will result better lazyload performance.`);
+          console.warn('[react-lazyload] A more specific `height` or `minHeight` for your own placeholder will result better lazyload performance.');
           warnedAboutPlaceholderHeight = true;
         }
       }
@@ -273,6 +273,6 @@ LazyLoad.defaultProps = {
   scroll: true
 };
 
+import decorator from './decorator';
+export const lazyload = decorator;
 export default LazyLoad;
-
-export lazyload from './decorator';

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -2,7 +2,7 @@
 // Generated on Wed Mar 18 2015 11:41:18 GMT+0800 (CST)
 'use strict';
 
-module.exports = function(config) {
+module.exports = function (config) {
   config.set({
 
     // base path that will be used to resolve all patterns (eg. files, exclude)
@@ -13,9 +13,9 @@ module.exports = function(config) {
     // available frameworks: https://npmjs.org/browse/keyword/karma-adapter
     frameworks: ['mocha', 'chai'],
 
-    // list of files / patterns to l/oad in the browser
+    // list of files / patterns to load in the browser
     files: [
-      {pattern: 'test/specs/*.js', included: true, watched: false},
+      { pattern: 'test/specs/*.js', included: true, watched: false },
     ],
 
 
@@ -39,7 +39,11 @@ module.exports = function(config) {
         loaders: [{
           test: /\.js$/,
           include: /src|test|demo/,
-          loader: 'babel?stage=0&loose=all'
+          query: {
+            presets: ['stage-0', 'es2015', 'react'],
+            plugins: ['transform-decorators-legacy']
+          },
+          loader: 'babel'
         }],
         postLoaders: [{
           test: /\.js$/,

--- a/test/specs/lazyload.spec.js
+++ b/test/specs/lazyload.spec.js
@@ -132,7 +132,7 @@ describe('LazyLoad', () => {
           </LazyLoad>
         </div>, div);
 
-      expect(log).to.have.been.called.with(`[react-lazyload] A more specific \`height\` or \`minHeight\` for your own placeholder will result better lazyload performance.`);
+      expect(log).to.have.been.called.with('[react-lazyload] A more specific `height` or `minHeight` for your own placeholder will result better lazyload performance.');
       console.warn = warn;
     });
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -27,7 +27,11 @@ module.exports = {
   module: {
     loaders: [{
       test: /\.jsx?$/,
-      loader: 'babel?stage=0&loose=all',
+      loader: 'babel',
+      query: {
+        presets: ['stage-0', 'es2015'],
+        plugins: ['transform-react-jsx', 'transform-decorators-legacy']
+      },
       exclude: /node_modules/
     }]
   },


### PR DESCRIPTION
AMD-ification doesn't like that `decorator.js` imports from './' and cries at me, so I made it more explicit so that it will stop crying!
